### PR TITLE
 Calling `brew cask cleanup` is deprecated and will be disabled on 20…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ bundle: | /usr/local/bin/brew
 	brew bundle
 	mas upgrade
 	brew cleanup
-	brew cask cleanup
 
 .PHONY: macos
 macos:


### PR DESCRIPTION
…18-09-30! Use `brew cleanup` instead